### PR TITLE
fix BootstrapWidgetTrait::registerPlugin

### DIFF
--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -76,11 +76,9 @@ trait BootstrapWidgetTrait
 
         $id = $this->options['id'];
 
-        if ($this->clientOptions !== []) {
-            $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
-            $js = "jQuery('#$id').$name($options);";
-            $view->registerJs($js);
-        }
+        $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
+        $js = "jQuery('#$id').$name($options);";
+        $view->registerJs($js);
 
         $this->registerClientEvents();
     }


### PR DESCRIPTION
`BootstrapWidgetTrait::registerPlugin` not working if empty `clientOptions` provided for plugin.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fix | #5 