### PR TITLE
fix BaseHtml::activeStaticControl

### DIFF
--- a/src/BaseHtml.php
+++ b/src/BaseHtml.php
@@ -73,7 +73,7 @@ abstract class BaseHtml extends \yii\helpers\Html
             $value = static::getAttributeValue($model, $attribute);
         }
 
-        return static::staticControl($value, $options);
+        return static::staticControl((string)$value, $options);
     }
 
     /**

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -76,11 +76,9 @@ trait BootstrapWidgetTrait
 
         $id = $this->options['id'];
 
-        if ($this->clientOptions !== []) {
-            $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
-            $js = "jQuery('#$id').$name($options);";
-            $view->registerJs($js);
-        }
+        $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
+        $js = "jQuery('#$id').$name($options);";
+        $view->registerJs($js);
 
         $this->registerClientEvents();
     }


### PR DESCRIPTION
BaseHtml::staticControl accept only string type value, but model attribute and $options['value'] can be `float`, `int` or even `null`. so typecast is supplied.


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #6 
