### PR TITLE
fix BaseHtml::activeStaticControl value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #6: yii\bootstrap5\BaseHtml::staticControl(): Argument #1 ($value) must be of type string, int given (dicrtarasov)
 
 
 2.0.1 August 11, 2021

--- a/src/BaseHtml.php
+++ b/src/BaseHtml.php
@@ -73,7 +73,7 @@ abstract class BaseHtml extends \yii\helpers\Html
             $value = static::getAttributeValue($model, $attribute);
         }
 
-        return static::staticControl($value, $options);
+        return static::staticControl((string)$value, $options);
     }
 
     /**

--- a/src/BaseHtml.php
+++ b/src/BaseHtml.php
@@ -49,7 +49,6 @@ abstract class BaseHtml extends \yii\helpers\Html
     public static function staticControl(string $value, array $options = []): string
     {
         static::addCssClass($options, 'form-control-plaintext');
-        $value = (string)$value;
         $options['readonly'] = true;
 
         return static::input('text', null, $value, $options);
@@ -64,7 +63,7 @@ abstract class BaseHtml extends \yii\helpers\Html
      * @return string generated HTML
      * @see staticControl()
      */
-    public static function activeStaticControl(Model $model, string $attribute, $options = []): string
+    public static function activeStaticControl(Model $model, string $attribute, array $options = []): string
     {
         if (isset($options['value'])) {
             $value = $options['value'];
@@ -77,7 +76,7 @@ abstract class BaseHtml extends \yii\helpers\Html
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public static function radioList($name, $selection = null, $items = [], $options = []): string
     {

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -310,6 +310,58 @@ HTML;
         $this->assertContainsWithoutLE($expected4, $out);
     }
 
+    public function testStaticControlRendering()
+    {
+        ActiveForm::$counter = 0;
+        ob_start();
+        $model = new User();
+        $model->setAttributes([
+            'id' => 1,
+            'firstName' => 'John',
+            'lastName' => 'Doe'
+        ]);
+        $form = ActiveForm::begin([
+            'action' => '/some-action',
+            'layout' => ActiveForm::LAYOUT_DEFAULT
+        ]);
+        echo $form->field($model, 'id')->staticControl();
+        echo $form->field($model, 'firstName')->staticControl();
+        echo $form->field($model, 'lastName')->staticControl();
+        echo $form->field($model, 'username')->staticControl();
+        ActiveForm::end();
+        $out = ob_get_clean();
+
+        $expected = <<<HTML
+<div class="mb-3 field-user-id">
+<label class="form-label" for="user-id">Id</label>
+<input type="text" class="form-control-plaintext" value="1" readonly>
+
+<div class="invalid-feedback"></div>
+</div>
+HTML;
+
+        $expected2 = <<<HTML
+<div class="mb-3 field-user-firstname">
+<label class="form-label" for="user-firstname">First Name</label>
+<input type="text" class="form-control-plaintext" value="John" readonly>
+
+<div class="invalid-feedback"></div>
+</div>
+HTML;
+        $expected3 = <<<HTML
+<div class="mb-3 field-user-lastname">
+<label class="form-label" for="user-lastname">Last Name</label>
+<input type="text" class="form-control-plaintext" value="Doe" readonly>
+
+<div class="invalid-feedback"></div>
+</div>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $out);
+        $this->assertContainsWithoutLE($expected2, $out);
+        $this->assertContainsWithoutLE($expected3, $out);
+    }
+
     /**
      * Fixes #128
      * @see https://github.com/yiisoft/yii2-bootstrap5/issues/128

--- a/tests/data/User.php
+++ b/tests/data/User.php
@@ -11,6 +11,7 @@ use yii\base\Model;
 
 class User extends Model
 {
+    public $id;
     public $firstName;
     public $lastName;
     public $username;
@@ -22,6 +23,8 @@ class User extends Model
     public function rules()
     {
         return [
+            ['id', 'integer'],
+            [['firstName', 'lastName'], 'string'],
             ['username', 'string', 'min' => 4],
             ['password', 'string', 'min' => 8, 'max' => '20'],
             [['username', 'password'], 'required']


### PR DESCRIPTION
```php
public static function activeStaticControl(Model $model, string $attribute, $options = []): string
    {
        if (isset($options['value'])) {
            $value = $options['value'];
            unset($options['value']);
        } else {
            $value = static::getAttributeValue($model, $attribute);
        }

        return static::staticControl($value, $options);
    }
```    

staticControl accept only `string` value argument, but model attribute value and $options['value'] can also be `int`, `float` or even `null`, so typecast is needed.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #6 
