### PR TITLE
fix default ActiveField::hintOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #9: fixed default ActiveField::hintOptions (dicrtarasov)
 
 
 2.0.1 August 11, 2021

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -494,7 +494,7 @@ class ActiveField extends \yii\widgets\ActiveField
     {
         $config = [
             'hintOptions' => [
-                'tag' => 'small',
+                'tag' => 'div',
                 'class' => ['form-text', 'text-muted'],
             ],
             'errorOptions' => [

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -156,7 +156,7 @@ class ActiveField extends \yii\widgets\ActiveField
     /**
      * {@inheritdoc}
      */
-    public $hintOptions = ['class' => ['widget' => 'form-text', 'text-muted'], 'tag' => 'small'];
+    public $hintOptions = ['class' => ['widget' => 'form-text', 'text-muted'], 'tag' => 'div'];
     /**
      * @var null|array CSS grid classes for horizontal layout. This must be an array with these keys:
      *  - 'offset' the offset grid class to append to the wrapper if no label is rendered

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -291,7 +291,7 @@ HTML;
 <div class="mb-3 field-user-username required">
 <label class="form-label" for="user-username">Username</label>
 <input type="text" id="user-username" class="form-control" name="User[username]" aria-required="true">
-<small class="form-text text-muted">Your username must be at least 4 characters long</small>
+<div class="form-text text-muted">Your username must be at least 4 characters long</div>
 <div class="invalid-feedback"></div>
 </div>
 HTML;
@@ -299,7 +299,7 @@ HTML;
 <div class="mb-3 field-user-password required">
 <label class="form-label" for="user-password">Password</label>
 <input type="password" id="user-password" class="form-control" name="User[password]" aria-required="true">
-<small class="form-text text-muted">Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.</small>
+<div class="form-text text-muted">Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.</div>
 <div class="invalid-feedback"></div>
 </div>
 HTML;
@@ -330,7 +330,7 @@ HTML;
 <div class="mb-3 field-user-username required">
 <label class="form-label" for="user-username">Username</label>
 <input type="text" id="user-username" class="form-control is-invalid" name="User[username]" aria-required="true" aria-invalid="true">
-<small class="form-text text-muted">Your username must be at least 4 characters long</small>
+<div class="form-text text-muted">Your username must be at least 4 characters long</div>
 <div class="invalid-feedback">Username cannot be blank.</div>
 </div>
 HTML;


### PR DESCRIPTION
Fix default attributeHint tag from `small` to `div` to restore normal rendering.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #9 

