### PR TITLE
Fix #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #5: BootstrapWidgetTrait::registerPlugin do nothing if no clientOptions is provided (dicrtarasov)
 
 
 2.0.1 August 11, 2021

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -76,11 +76,9 @@ trait BootstrapWidgetTrait
 
         $id = $this->options['id'];
 
-        if ($this->clientOptions !== []) {
-            $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
-            $js = "jQuery('#$id').$name($options);";
-            $view->registerJs($js);
-        }
+        $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
+        $js = "jQuery('#$id').$name($options);";
+        $view->registerJs($js);
 
         $this->registerClientEvents();
     }

--- a/tests/ToastTest.php
+++ b/tests/ToastTest.php
@@ -2,7 +2,10 @@
 
 namespace yiiunit\extensions\bootstrap5;
 
+use PHPUnit\Framework\Constraint\IsType;
+use Yii;
 use yii\bootstrap5\Toast;
+use yii\web\View;
 
 /**
  * @group bootstrap5
@@ -112,5 +115,31 @@ HTML;
 HTML;
 
         $this->assertEqualsWithoutLE($expected, $out);
+    }
+
+    /**
+     * @see https://github.com/yiisoft/yii2-bootstrap5/issues/5
+     */
+    public function testWidgetInitialization()
+    {
+        Toast::$counter = 0;
+        ob_start();
+        $toast = Toast::begin([
+            'title' => 'Toast title',
+            'titleOptions' => ['tag' => 'h5', 'style' => ['text-align' => 'left']]
+        ]);
+        echo 'test';
+        Toast::end();
+        $out = ob_get_clean();
+
+        $this->assertInternalType(IsType::TYPE_ARRAY, $toast->clientOptions);
+        $this->assertCount(0, $toast->clientOptions);
+
+        $js = Yii::$app->view->js[View::POS_READY];
+
+        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $options = array_shift($js);
+
+        $this->assertContainsWithoutLE("jQuery('#w0').toast();", $options);
     }
 }


### PR DESCRIPTION
`BootstrapWidgetTrait::registerPlugin` not working if empty `clientOptions` provided for plugin.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fix | #5 