### PR TITLE
Accept `Breadcrumbs::$homeLink = false` to omit "Home" link

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -40,7 +40,7 @@ class Breadcrumbs extends Widget
      */
     public $encodeLabels = true;
     /**
-     * @var array the first hyperlink in the breadcrumbs (called home link).
+     * @var array|false the first hyperlink in the breadcrumbs (called home link).
      * Please refer to [[links]] on the format of the link.
      * If this property is not set, it will default to a link pointing to [[\yii\web\Application::homeUrl]]
      * with the label 'Home'. If this property is false, the home link will not be rendered.
@@ -113,7 +113,7 @@ class Breadcrumbs extends Widget
                 'label' => 'Home',
                 'url' => '/',
             ], $this->itemTemplate);
-        } else {
+        } elseif ($this->homeLink !== false) {
             $links[] = $this->renderItem($this->homeLink, $this->itemTemplate);
         }
 

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -30,4 +30,24 @@ HTML;
 
         $this->assertEqualsWithoutLE($expected, $out);
     }
+
+    public function testRenderWithoutHomeLink()
+    {
+        Breadcrumbs::$counter = 0;
+        $out = Breadcrumbs::widget([
+            'homeLink' => false,
+            'links' => [
+                ['label' => 'Library', 'url' => '#'],
+                ['label' => 'Data']
+            ]
+        ]);
+
+        $expected = <<<HTML
+<nav aria-label="breadcrumb"><ol id="w0" class="breadcrumb"><li class="breadcrumb-item"><a href="#">Library</a></li>
+<li class="breadcrumb-item active" aria-current="page">Data</li>
+</ol></nav>
+HTML;
+
+        $this->assertEqualsWithoutLE($expected, $out);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

The phpdoc of `Breadcrumbs::$homeLink` says ["If this property is false, the home link will not be rendered."](https://github.com/yiisoft/yii2-bootstrap5/blob/960529d8b4b650955fae0e4feb23c54fd6397959/src/Breadcrumbs.php#L46)
However, if it is `false`, a TypeError will be raised.

Note: `yii2-bootstrap4` also [has the same phpdoc](https://github.com/yiisoft/yii2-bootstrap4/blob/a0280a6caefbf153ab49664c9ef129675dd02040/src/Breadcrumbs.php#L44), and [it works](https://github.com/yiisoft/yii2-bootstrap4/blob/a0280a6caefbf153ab49664c9ef129675dd02040/src/Breadcrumbs.php#L108) actually.