### PR TITLE
Remove redundand BaseHtml::$dataAttributes

### DIFF
--- a/src/BaseHtml.php
+++ b/src/BaseHtml.php
@@ -27,13 +27,6 @@ abstract class BaseHtml extends \yii\helpers\Html
      * @see getId()
      */
     public static $autoIdPrefix = 'i';
-    /**
-     * @var array list of tag attributes that should be specially handled when their values are of array type.
-     * In particular, if the value of the `data` attribute is `['name' => 'xyz', 'age' => 13]`, two attributes
-     * will be generated instead of one: `data-name="xyz" data-age="13"`.
-     * @since 2.0.3
-     */
-    public static $dataAttributes = ['data', 'data-ng', 'ng', 'aria'];
 
 
     /**


### PR DESCRIPTION
Same to parent value

https://github.com/yiisoft/yii2/blob/08da35e511e83b2184e6dfa46ec8232058ff4b2d/framework/helpers/BaseHtml.php#L96

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
