### PR TITLE
fix: clientOptions=false skips registerJs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 
 2.0.3 under development
 -----------------------
-
+- Enh #36: `BootstrapWidgetTrait::$clientOptions = false` disables registerJs in `BootstrapWidgetTrait` (julianrutten)
 - Enh #33: Updated russian translations (WinterSilence)
 - Enh #28: Added translations (simialbi)
 - Enh #24: Accept `Breadcrumbs::$homeLink = false` to omit "Home" link (fetus-hina)

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -76,10 +76,12 @@ trait BootstrapWidgetTrait
 
         $id = $this->options['id'];
 
-        $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
-        $js = "jQuery('#$id').$name($options);";
-        $view->registerJs($js);
-
+        if($this->clientOptions !== false){
+            $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
+            $js = "jQuery('#$id').$name($options);";
+            $view->registerJs($js);
+        }
+        
         $this->registerClientEvents();
     }
 

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -35,10 +35,11 @@ use yii\helpers\Json;
 trait BootstrapWidgetTrait
 {
     /**
-     * @var array the options for the underlying Bootstrap JS plugin.
+     * @var array|bool the options for the underlying Bootstrap JS plugin.
      * Please refer to the corresponding Bootstrap plugin Web page for possible options.
      * For example, [this page](http://getbootstrap.com/javascript/#modals) shows
      * how to use the "Modal" plugin and the supported options (e.g. "remote").
+     * If this property is false, registerJs will not be called on the view to initialize the module.
      */
     public $clientOptions = [];
     /**

--- a/tests/ToastTest.php
+++ b/tests/ToastTest.php
@@ -142,4 +142,51 @@ HTML;
 
         $this->assertContainsWithoutLE("jQuery('#w0').toast();", $options);
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2-bootstrap5/issues/36
+     */
+    public function testWidgetNoInitialization()
+    {
+        Toast::$counter = 0;
+        ob_start();
+        $toast = Toast::begin([
+            'title' => 'Toast title',
+            'clientOptions' => false,
+            'titleOptions' => ['tag' => 'h5', 'style' => ['text-align' => 'left']]
+        ]);
+        echo 'test';
+        Toast::end();
+        $out = ob_get_clean();
+
+        $this->assertFalse($toast->clientOptions);
+        $this->assertArrayNotHasKey(View::POS_READY,Yii::$app->view->js);
+    }
+
+    /**
+     * 
+     * @see https://github.com/yiisoft/yii2-bootstrap5/issues/36
+     */
+    public function testWidgetInitializationTrue()
+    {
+        Toast::$counter = 0;
+        ob_start();
+        $toast = Toast::begin([
+            'title' => 'Toast title',
+            'clientOptions' => true,
+            'titleOptions' => ['tag' => 'h5', 'style' => ['text-align' => 'left']]
+        ]);
+        echo 'test';
+        Toast::end();
+        $out = ob_get_clean();
+
+        $this->assertTrue($toast->clientOptions);
+        $this->assertArrayHasKey(View::POS_READY,Yii::$app->view->js);
+        $js = Yii::$app->view->js[View::POS_READY];
+
+        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $options = array_shift($js);
+
+        $this->assertContainsWithoutLE("jQuery('#w0').toast(true);", $options);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ 
| New feature?  | ❌
| Breaks BC?    | ❌ Not compared to previous versions. See issue.
| Fixed issues  | #36
