### PR TITLE
Fixed `homeUrl` in default `homeLink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Enh #18: Add rangeInput(), colorInput() and switch mode to checkbox() in class ActiveField (WinterSilence)
 - Bug #19: Fix value of attribute "aria-current" in LinkPager::renderPageButton() (WinterSilence)
 - Bug #23: Fix class attribute in listBox() and dropDownList() of class ActiveField (WinterSilence)
-- Bug #133: Fix default `homeUrl` in `Breadcrumbs::$homeLink` (luke-)
+- Bug #133: Fix default `homeUrl` in `Breadcrumbs` widget (luke-)
 
 
 2.0.2 October 21, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Enh #18: Add rangeInput(), colorInput() and switch mode to checkbox() in class ActiveField (WinterSilence)
 - Bug #19: Fix value of attribute "aria-current" in LinkPager::renderPageButton() (WinterSilence)
 - Bug #23: Fix class attribute in listBox() and dropDownList() of class ActiveField (WinterSilence)
+- Bug #133: Fix default `homeUrl` in `Breadcrumbs::$homeLink` (luke-)
 
 
 2.0.2 October 21, 2021

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -111,7 +111,7 @@ class Breadcrumbs extends Widget
         if ($this->homeLink === []) {
             $links[] = $this->renderItem([
                 'label' => Yii::t('yii/bootstrap5', 'Home'),
-                'url' => '/',
+                'url' => Yii::$app->homeUrl,
             ], $this->itemTemplate);
         } elseif ($this->homeLink !== false) {
             $links[] = $this->renderItem($this->homeLink, $this->itemTemplate);

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -63,7 +63,7 @@ HTML;
         ]);
 
         $expected = <<<HTML
-<nav aria-label="breadcrumb"><ol id="w0" class="breadcrumb"><li class="breadcrumb-item"><a href="/">Start</a></li>
+<nav aria-label="breadcrumb"><ol id="w0" class="breadcrumb"><li class="breadcrumb-item"><a href="/index.php">Start</a></li>
 <li class="breadcrumb-item"><a href="#">Library</a></li>
 <li class="breadcrumb-item active" aria-current="page">Data</li>
 </ol></nav>


### PR DESCRIPTION
The Phpdoc descriptions says "If this property is not set, it will default to a link pointing to [[\yii\web\Application::homeUrl]] with the label 'Home'. If this property is false, the home link will not be rendered."

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
