### PR TITLE
Breadcrumbs refactoring

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -9,67 +9,62 @@ declare(strict_types=1);
 
 namespace yii\bootstrap5;
 
-use RuntimeException;
 use Yii;
 use yii\helpers\ArrayHelper;
 
 /**
- * Breadcrumbs represents a Bootstrap 5 version of [[\yii\widgets\Breadcrumbs]]. It displays
- * a list of links indicating the position of the current page in the whole site hierarchy.
- *
- * To use Breadcrumbs, you need to configure its [[links]] property, which specifies the links to be displayed. For example,
+ * This widget represents a Bootstrap 5 component "Breadcrumb". It displays a list of links indicating the
+ * position of the current page in the whole site hierarchy.
  *
  * ```php
  * echo Breadcrumbs::widget([
- *     'links' => isset($this->params['breadcrumbs']) ? $this->params['breadcrumbs'] : [],
- *     'options' => [],
+ *     'links' => [
+ *         [
+ *             'label' => 'the item label', // required
+ *             'url' => 'the item URL', // optional, will be processed by `Url::to()`
+ *             'template' => 'own template of the item', // optional
+ *          ],
+ *          ['label' => 'the label of the active item']
+ *     ],
+ *     'options' => [...],
  * ]);
  * ```
+ * or
+ * ```php
+ * echo Breadcrumbs::widget([
+ *     'links' => [
+ *         'the item URL' => 'the item label',
+ *          0 => 'the label of the active item',
+ *     ],
+ *     'options' => [...],
+ * ]);
+ * ```
+ *
  * @see https://getbootstrap.com/docs/5.1/components/breadcrumb/
  * @author Alexandr Kozhevnikov <onmotion1@gmail.com>
  * @author Simon Karlen <simi.albi@outlook.com>
  */
-class Breadcrumbs extends Widget
+class Breadcrumbs extends \yii\widgets\Breadcrumbs
 {
+    use BootstrapWidgetTrait;
+
     /**
-     * @var string the name of the breadcrumb container tag.
+     * {@inheritDoc}
      */
     public $tag = 'ol';
     /**
-     * @var bool whether to HTML-encode the link labels.
-     */
-    public $encodeLabels = true;
-    /**
-     * @var array|bool the first hyperlink in the breadcrumbs (called home link).
+     * @var array|false the first hyperlink in the breadcrumbs (called home link).
      * Please refer to [[links]] on the format of the link.
      * If this property is not set, it will default to a link pointing to [[\yii\web\Application::homeUrl]]
      * with the label 'Home'. If this property is false, the home link will not be rendered.
      */
     public $homeLink = [];
     /**
-     * @var array list of links to appear in the breadcrumbs. If this property is empty,
-     * the widget will not render anything. Each array element represents a single link in the breadcrumbs
-     * with the following structure:
-     *
-     * ```php
-     * [
-     *     'label' => 'label of the link',  // required
-     *     'url' => 'url of the link',      // optional, will be processed by Url::to()
-     *     'template' => 'own template of the item', // optional, if not set $this->itemTemplate will be used
-     * ]
-     * ```
-     *
-     *
-     */
-    public $links = [];
-    /**
-     * @var string the template used to render each inactive item in the breadcrumbs. The token `{link}`
-     * will be replaced with the actual HTML link for each inactive item.
+     * {@inheritDoc}
      */
     public $itemTemplate = "<li class=\"breadcrumb-item\">{link}</li>\n";
     /**
-     * @var string the template used to render each active item in the breadcrumbs. The token `{link}`
-     * will be replaced with the actual HTML link for each active item.
+     * {@inheritDoc}
      */
     public $activeItemTemplate = "<li class=\"breadcrumb-item active\" aria-current=\"page\">{link}</li>\n";
     /**
@@ -78,54 +73,37 @@ class Breadcrumbs extends Widget
      */
     public $navOptions = ['aria' => ['label' => 'breadcrumb']];
 
-
-    /**
-     * Initializes the widget.
-     * If you override this method, make sure you call the parent implementation first.
-     */
-    public function init()
-    {
-        parent::init();
-        $this->clientOptions = [];
-        Html::addCssClass($this->options, ['widget' => 'breadcrumb']);
-    }
-
     /**
      * {@inheritDoc}
      */
     public function run(): string
     {
-        if (!isset($this->options['id'])) {
-            $this->options['id'] = "{$this->getId()}-breadcrumb";
-        }
-
-        /** @psalm-suppress InvalidArgument */
-        Html::addCssClass($this->options, ['widget' => 'breadcrumb']);
-
         if (empty($this->links)) {
             return '';
         }
 
+        // Normalize links
         $links = [];
+        foreach ($this->links as $key => $value) {
+            if (is_array($value)) {
+                $links[] = $value;
+            } else {
+                $links[] = ['label' => $value, 'url' => is_string($key) ? $key : null];
+            }
+        }
+        $this->links = $links;
+        unset($links);
 
         if ($this->homeLink === []) {
-            $links[] = $this->renderItem([
-                'label' => Yii::t('yii/bootstrap5', 'Home'),
-                'url' => Yii::$app->homeUrl,
-            ], $this->itemTemplate);
-        } elseif ($this->homeLink !== false) {
-            $links[] = $this->renderItem($this->homeLink, $this->itemTemplate);
+            $this->homeLink = null;
         }
 
-        foreach ($this->links as $link) {
-            if (!is_array($link)) {
-                $link = ['label' => $link];
-            }
-
-            $links[] = $this->renderItem($link, isset($link['url']) ? $this->itemTemplate : $this->activeItemTemplate);
+        if (!isset($this->options['id'])) {
+            $this->options['id'] = "{$this->getId()}-breadcrumb";
         }
+        Html::addCssClass($this->options, ['widget' => 'breadcrumb']);
 
-        return Html::tag('nav', Html::tag($this->tag, implode('', $links), $this->options), $this->navOptions);
+        return Html::tag('nav', parent::run(), $this->navOptions);
     }
 
     /**
@@ -165,7 +143,7 @@ class Breadcrumbs extends Widget
      * If this property is not set, it will default to a link pointing with the label 'Home'. If this property is false,
      * the home link will not be rendered.
      *
-     * @param array|bool $value
+     * @param array|false $value
      *
      * @return $this
      */
@@ -192,16 +170,8 @@ class Breadcrumbs extends Widget
     }
 
     /**
-     * List of links to appear in the breadcrumbs. If this property is empty, the widget will not render anything. Each
-     * array element represents a single link in the breadcrumbs with the following structure:
-     *
-     * ```php
-     * [
-     *     'label' => 'label of the link',  // required
-     *     'url' => 'url of the link',      // optional, will be processed by Url::to()
-     *     'template' => 'own template of the item', // optional, if not set $this->itemTemplate will be used
-     * ]
-     * ```
+     * List of links to appear in the breadcrumbs. If this property is empty, the widget will not render anything.
+     * Each array element represents a single item in the breadcrumbs with the following structure.
      *
      * @param array $value
      *
@@ -258,41 +228,5 @@ class Breadcrumbs extends Widget
         $this->tag = $value;
 
         return $this;
-    }
-
-    /**
-     * Renders a single breadcrumb item.
-     *
-     * @param array $link the link to be rendered. It must contain the "label" element. The "url" element is optional.
-     * @param string $template the template to be used to rendered the link. The token "{link}" will be replaced by the
-     * link.
-     *
-     * @return string the rendering result
-     * @throws RuntimeException if `$link` does not have "label" element.
-     *
-     */
-    protected function renderItem(array $link, string $template): string
-    {
-        $encodeLabel = ArrayHelper::remove($link, 'encode', $this->encodeLabels);
-
-        if (array_key_exists('label', $link)) {
-            $label = $encodeLabel ? Html::encode($link['label']) : $link['label'];
-        } else {
-            throw new RuntimeException('The "label" element is required for each link.');
-        }
-
-        if (isset($link['template'])) {
-            $template = $link['template'];
-        }
-
-        if (isset($link['url'])) {
-            $options = $link;
-            unset($options['template'], $options['label'], $options['url']);
-            $linkHtml = Html::a($label, $link['url'], $options);
-        } else {
-            $linkHtml = $label;
-        }
-
-        return strtr($template, ['{link}' => $linkHtml]);
     }
 }


### PR DESCRIPTION
Class extends `yii\widget\Breadcrumbs`
Remove redundant code
Add short format for `Breadcrumbs::$links`

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
