### PR TITLE
build(*): Fix CI by allowing the yii2-composer plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,7 @@ jobs:
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
             - name: Install dependencies
-              run: |
-                  composer config --no-plugins allow-plugins.yiisoft/yii2-composer true
-                  composer update $DEFAULT_COMPOSER_FLAGS
+              run: composer update $DEFAULT_COMPOSER_FLAGS
             - name: Run unit tests with coverage
               run: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover --colors=always
               if: matrix.php == '7.4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
             - name: Install dependencies
-              run: composer update $DEFAULT_COMPOSER_FLAGS
+              run: |
+                  composer config --no-plugins allow-plugins.yiisoft/yii2-composer true
+                  composer update $DEFAULT_COMPOSER_FLAGS
             - name: Run unit tests with coverage
               run: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover --colors=always
               if: matrix.php == '7.4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
+                php: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
 
         steps:
             - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,11 @@
     "suggest": {
         "twbs/bootstrap-icons": "Add this package to the `require` section of your `composer.json` if you'd like to use the bootstrap icon asset."
     },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
+    },
     "repositories": [
         {
             "type": "composer",


### PR DESCRIPTION
This PR fixes the CI that broke due to the composer 2 allow-plugins setting. See failure in #46.

PS: I was initially looking at adding PHP 8.1 in the CI, but I see that we need to fix a compatibility with PHPUnit first (see first failure).