### PR TITLE
Nav::isItemActive(): Return value must be of type bool, int returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.5 under development
 -----------------------
 
-- Bug #62: Navbar can now accept `collapseOptions` to be `false` (theblindfrog)
 - Bug #72: Nav::isItemActive(): Return value must be of type bool, int returned (hirenbhut93)
+- Bug #62: Navbar can now accept `collapseOptions` to be `false` (theblindfrog)
 
 2.0.4 November 30, 2022
 -----------------------

--- a/src/Nav.php
+++ b/src/Nav.php
@@ -278,7 +278,7 @@ class Nav extends Widget
             return false;
         }
         if (isset($item['active'])) {
-            return ArrayHelper::getValue($item, 'active', false);
+            return (bool)ArrayHelper::getValue($item, 'active', false);
         }
         if (isset($item['url']) && is_array($item['url']) && isset($item['url'][0])) {
             $route = $item['url'][0];


### PR DESCRIPTION
Due to Exception 'TypeError' with message 'yii\bootstrap5\Nav::isItemActive(): Return value must be of type bool, int returned'

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
