### PR TITLE
Checkbox labels should not be hidden in inline forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Bug #74: Bootstrap5 Button is not registering clientEvents (simialbi)
 - Bug #72: Nav::isItemActive(): Return value must be of type bool, int returned (hirenbhut93)
 - Bug #62: Navbar can now accept `collapseOptions` to be `false` (theblindfrog)
+- Bug #??: Checkbox labels in inline forms are no longer hidden (BBoom)
 
 
 2.0.4 November 30, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Bug #74: Bootstrap5 Button is not registering clientEvents (simialbi)
 - Bug #72: Nav::isItemActive(): Return value must be of type bool, int returned (hirenbhut93)
 - Bug #62: Navbar can now accept `collapseOptions` to be `false` (theblindfrog)
-- Bug #??: Checkbox labels in inline forms are no longer hidden (BBoom)
+- Bug #84: Checkbox labels in inline forms are no longer hidden (BBoom)
 
 
 2.0.4 November 30, 2022

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -292,6 +292,9 @@ class ActiveField extends \yii\widgets\ActiveField
             Html::removeCssClass($this->labelOptions, $this->horizontalCssClasses['label']);
             Html::addCssClass($this->wrapperOptions, $this->horizontalCssClasses['offset']);
         }
+        if ($this->form->layout === ActiveForm::LAYOUT_INLINE) {
+            Html::removeCssClass($this->labelOptions, 'visually-hidden');
+        }
         Html::removeCssClass($this->labelOptions, 'form-label');
         unset($options['template'], $options['switch']);
 

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -184,7 +184,7 @@ HTML;
 <div class="mb-3 field-dynamicmodel-checkboxname">
 <div class="form-check">
 <input type="hidden" name="DynamicModel[checkboxName]" value="0"><input type="checkbox" id="dynamicmodel-checkboxname" class="form-check-input" name="DynamicModel[checkboxName]" value="1">
-<label class="visually-hidden form-check-label" for="dynamicmodel-checkboxname">Checkbox Name</label>
+<label class="form-check-label" for="dynamicmodel-checkboxname">Checkbox Name</label>
 
 
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Note: This is the same issue fixed in https://github.com/yiisoft/yii2-bootstrap4/pull/243 for bootstrap 4.

--
Inline forms by default hide all labels with the sr-only class. This should not happen for checkbox elements, which need their label to function. Without a visible label, the checkbox will not function in bootstrap. And even if it did, a checkbox without a label is not really usable.

The method for class removal is based on similar exceptions made in the listBox() and dropDownList() methods in the same class.