### PR TITLE
Added view option to render a view with Yii inside tab content

### DIFF
--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 namespace yii\bootstrap5;
-
+use Yii;
 use Exception;
 use Throwable;
 use yii\base\InvalidConfigException;
@@ -75,6 +75,7 @@ class Tabs extends Widget
      * - headerOptions: array, optional, the HTML attributes of the tab header.
      * - linkOptions: array, optional, the HTML attributes of the tab header link tags.
      * - content: string, optional, the content (HTML) of the tab pane.
+     * - view: array, optional, the view that should be rendered with Yii::$app->controller->view->render
      * - url: string, optional, an external URL. When this is specified, clicking on this tab will bring
      *   the browser to this URL. This option is available since version 2.0.4.
      * - options: array, optional, the HTML attributes of the tab pane container.
@@ -232,7 +233,12 @@ class Tabs extends Widget
 
             if ($this->renderTabContent) {
                 $tag = ArrayHelper::remove($options, 'tag', 'div');
-                $this->panes[] = Html::tag($tag, $item['content'] ?? '', $options);
+                $view = ArrayHelper::getValue($item, 'view');
+                $content = ArrayHelper::getValue($item, 'content', '');
+                if (!$content && $view) {
+                    $content = Yii::$app->controller->renderPartial($view[0], ArrayHelper::getValue($view, 1, []));
+                }
+                $this->panes[] = Html::tag($tag, $content, $options);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

Adds the posibility to render a view inside a Tab content.
```php
echo Tabs::widget([
    'items'   =>[
        [
            'label'   => 'Tab label',
            'view'    => ['@app/views/site/my-view',['param1'=>'value1']],
            'visible' => true,
        ],
    ],
]);
```

The main benefit is that when used with visible = false it won't render the view.
