### PR TITLE
Fix `ButtonDropdown` JS error

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -49,7 +49,9 @@ class Button extends Widget
     public function init()
     {
         parent::init();
-        $this->clientOptions = [];
+        if ($this->clientOptions !== false) {
+            $this->clientOptions = [];
+        }
         Html::addCssClass($this->options, ['widget' => 'btn']);
     }
 

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -191,6 +191,7 @@ class ButtonDropdown extends Widget
                 'tagName' => $this->tagName,
                 'label' => $label,
                 'options' => $buttonOptions,
+                'clientOptions' => false,
                 'encodeLabel' => false,
                 'view' => $this->getView(),
             ]) . "\n" . $splitButton;


### PR DESCRIPTION
Fix 'Bootstrap doesn't allow more than one instance per element. Bound instance: bs.dropdown.' JS error when using `ButtonDropdown`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
