### PR TITLE
fixed php8.4 deprecated Implicitly marking parameter as nullable

### DIFF
--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -106,7 +106,7 @@ trait BootstrapWidgetTrait
     /**
      * Registers JS event handlers that are listed in [[clientEvents]].
      */
-    protected function registerClientEvents(string $name = null)
+    protected function registerClientEvents(?string $name = null)
     {
         if (!empty($this->clientEvents)) {
             $id = $this->options['id'];


### PR DESCRIPTION
fixed Implicitly marking parameter as nullable that is deprecated in php8.4
php docs:

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated#change
