### PR TITLE
Fix PHP 8.4 "Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead" error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
+                php: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             - name: Cache composer dependencies
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.5 under development
 -----------------------
 
-- Bug #92: Explicit nullable parameter (OneMorePenguin)
+- Bug #92: Explicit nullable parameter (OneMorePenguin, simialbi)
 - Enh #78: Navbar has new attribute `brandImageOptions` (EvilKarter)
 - Bug #74: Bootstrap5 Button is not registering clientEvents (simialbi)
 - Bug #72: Nav::isItemActive(): Return value must be of type bool, int returned (hirenbhut93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #92: Explicit nullable parameter (OneMorePenguin)
 - Enh #78: Navbar has new attribute `brandImageOptions` (EvilKarter)
 - Bug #74: Bootstrap5 Button is not registering clientEvents (simialbi)
 - Bug #72: Nav::isItemActive(): Return value must be of type bool, int returned (hirenbhut93)

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.3",
         "ext-json": "*",
         "yiisoft/yii2": "^2.0.42",
         "bower-asset/bootstrap": "^5.1.0"
     },
     "require-dev": {
         "yiisoft/yii2-coding-standards": "~2.0",
-        "phpunit/phpunit": "^6.5.14",
+        "phpunit/phpunit": "^9.6",
         "twbs/bootstrap-icons": "^1.7.2"
     },
     "suggest": {

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -608,7 +608,7 @@ class ActiveField extends \yii\widgets\ActiveField
      * @param string|null $label the label or null to use model label
      * @param array $options the tag options
      */
-    protected function renderLabelParts(string $label = null, array $options = [])
+    protected function renderLabelParts(string|null $label = null, array $options = [])
     {
         $options = array_merge($this->labelOptions, $options);
         if ($label === null) {

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -608,7 +608,7 @@ class ActiveField extends \yii\widgets\ActiveField
      * @param string|null $label the label or null to use model label
      * @param array $options the tag options
      */
-    protected function renderLabelParts(string|null $label = null, array $options = [])
+    protected function renderLabelParts(?string $label = null, array $options = [])
     {
         $options = array_merge($this->labelOptions, $options);
         if ($label === null) {

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -106,7 +106,7 @@ trait BootstrapWidgetTrait
     /**
      * Registers JS event handlers that are listed in [[clientEvents]].
      */
-    protected function registerClientEvents(string $name = null)
+    protected function registerClientEvents(string|null $name = null)
     {
         if (!empty($this->clientEvents)) {
             $id = $this->options['id'];

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -106,7 +106,7 @@ trait BootstrapWidgetTrait
     /**
      * Registers JS event handlers that are listed in [[clientEvents]].
      */
-    protected function registerClientEvents(string|null $name = null)
+    protected function registerClientEvents(?string $name = null)
     {
         if (!empty($this->clientEvents)) {
             $id = $this->options['id'];

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -215,10 +215,10 @@ HTML
 
     /**
      * @dataProvider invalidItemsProvider
-     * @expectedException \yii\base\InvalidConfigException
      */
     public function testMissingLabel($items)
     {
+        $this->expectException(\yii\base\InvalidConfigException::class);
         Accordion::widget([
             'items' => $items,
         ]);
@@ -278,12 +278,12 @@ HTML
         $output = Accordion::widget([
             'items' => $items
         ]);
-        $this->assertContains('data-bs-parent="', $output);
+        $this->assertStringContainsString('data-bs-parent="', $output);
         $output = Accordion::widget([
             'autoCloseItems' => false,
             'items' => $items
         ]);
-        $this->assertNotContains('data-bs-parent="', $output);
+        $this->assertStringNotContainsString('data-bs-parent="', $output);
     }
 
     /**
@@ -310,8 +310,8 @@ HTML
                 'class' => 'custom-toggle',
             ],
         ]);
-        $this->assertContains('<h5 class="mb-0"><a type="button" class="custom-toggle" href="#w0-collapse0" ', $output);
-        $this->assertNotContains('<button', $output);
+        $this->assertStringContainsString('<h5 class="mb-0"><a type="button" class="custom-toggle" href="#w0-collapse0" ', $output);
+        $this->assertStringNotContainsString('<button', $output);
 
         $output = Accordion::widget([
             'items' => $items,
@@ -320,7 +320,7 @@ HTML
                 'class' => ['widget' => 'custom-toggle'],
             ],
         ]);
-        $this->assertContains('<h5 class="mb-0"><a type="button" class="custom-toggle" href="#w1-collapse0" ', $output);
-        $this->assertNotContains('collapse-toggle', $output);
+        $this->assertStringContainsString('<h5 class="mb-0"><a type="button" class="custom-toggle" href="#w1-collapse0" ', $output);
+        $this->assertStringNotContainsString('collapse-toggle', $output);
     }
 }

--- a/tests/ActiveFieldDefaultFormCheckTest.php
+++ b/tests/ActiveFieldDefaultFormCheckTest.php
@@ -189,7 +189,7 @@ HTML;
         $this->assertContainsWithoutLE($expected3, $out);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // dirty way to have Request object not throwing exception when running testHomeLinkNull()
         $_SERVER['SCRIPT_FILENAME'] = 'index.php';

--- a/tests/ActiveFieldTest.php
+++ b/tests/ActiveFieldTest.php
@@ -291,7 +291,7 @@ HTML;
             ]
         ])->render();
 
-        $this->assertContains('data-attribute="test"', $content);
+        $this->assertStringContainsString('data-attribute="test"', $content);
     }
 
     /**
@@ -306,10 +306,10 @@ HTML;
             ]
         ])->render();
 
-        $this->assertContains('data-attribute="test"', $content);
+        $this->assertStringContainsString('data-attribute="test"', $content);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // dirty way to have Request object not throwing exception when running testHomeLinkNull()
         $_SERVER['SCRIPT_FILENAME'] = "index.php";

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -397,7 +397,7 @@ HTML;
     {
         $form = ActiveForm::widget();
 
-        $this->assertNotContains('role="form"', $form);
+        $this->assertStringNotContainsString('role="form"', $form);
     }
 
     public function testErrorSummaryRendering()
@@ -418,7 +418,7 @@ HTML;
         $this->assertContainsWithoutLE('<div class="alert alert-danger"', $out);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // dirty way to have Request object not throwing exception when running testFormNoRoleAttribute()
         $_SERVER['REQUEST_URI'] = "index.php";

--- a/tests/ButtonDropdownTest.php
+++ b/tests/ButtonDropdownTest.php
@@ -28,7 +28,7 @@ class ButtonDropdownTest extends TestCase
             ],
         ]);
 
-        $this->assertContains("$containerClass dropup btn-group", $out);
+        $this->assertStringContainsString("$containerClass dropup btn-group", $out);
     }
 
     public function testDirection()

--- a/tests/CarouselTest.php
+++ b/tests/CarouselTest.php
@@ -90,6 +90,6 @@ HTML;
             ]
         ]);
 
-        $this->assertContains('class="carousel slide carousel-fade"', $out);
+        $this->assertStringContainsString('class="carousel slide carousel-fade"', $out);
     }
 }

--- a/tests/LinkPagerTest.php
+++ b/tests/LinkPagerTest.php
@@ -25,22 +25,22 @@ class LinkPagerTest extends TestCase
             'firstPageLabel' => true,
             'lastPageLabel' => true,
         ]);
-        $this->assertContains('<li class="page-item first"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>', $output);
-        $this->assertContains('<li class="page-item last"><a class="page-link" href="/?r=test&amp;page=25" data-page="24">25</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item first"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item last"><a class="page-link" href="/?r=test&amp;page=25" data-page="24">25</a></li>', $output);
         $output = LinkPager::widget([
             'pagination' => $pagination,
             'firstPageLabel' => 'First',
             'lastPageLabel' => 'Last',
         ]);
-        $this->assertContains('<li class="page-item first"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">First</a></li>', $output);
-        $this->assertContains('<li class="page-item last"><a class="page-link" href="/?r=test&amp;page=25" data-page="24">Last</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item first"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">First</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item last"><a class="page-link" href="/?r=test&amp;page=25" data-page="24">Last</a></li>', $output);
         $output = LinkPager::widget([
             'pagination' => $pagination,
             'firstPageLabel' => false,
             'lastPageLabel' => false,
         ]);
-        $this->assertNotContains('<li class="page-item first">', $output);
-        $this->assertNotContains('<li class="page-item last">', $output);
+        $this->assertStringNotContainsString('<li class="page-item first">', $output);
+        $this->assertStringNotContainsString('<li class="page-item last">', $output);
     }
 
     public function testDisabledPageElementOptions()
@@ -49,7 +49,7 @@ class LinkPagerTest extends TestCase
             'pagination' => $this->getPagination(0),
             'disabledListItemSubTagOptions' => ['class' => ['foo-bar']],
         ]);
-        $this->assertContains('<li class="page-item prev disabled"><a class="page-link foo-bar"', $output);
+        $this->assertStringContainsString('<li class="page-item prev disabled"><a class="page-link foo-bar"', $output);
     }
 
     /**
@@ -60,7 +60,7 @@ class LinkPagerTest extends TestCase
             'pagination' => $this->getPagination(0),
             'disabledListItemSubTagOptions' => ['class' => new ReplaceArrayValue(['foo-bar'])],
         ]);
-        $this->assertContains('<li class="page-item prev disabled"><a class="foo-bar"', $output);
+        $this->assertStringContainsString('<li class="page-item prev disabled"><a class="foo-bar"', $output);
     }
 
     public function testDisableCurrentPageButton()
@@ -70,12 +70,12 @@ class LinkPagerTest extends TestCase
             'pagination' => $pagination,
             'disableCurrentPageButton' => false,
         ]);
-        $this->assertContains('<li class="page-item active" aria-current="page"><a class="page-link" href="/?r=test&amp;page=6" data-page="5">6</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item active" aria-current="page"><a class="page-link" href="/?r=test&amp;page=6" data-page="5">6</a></li>', $output);
         $output = LinkPager::widget([
             'pagination' => $pagination,
             'disableCurrentPageButton' => true,
         ]);
-        $this->assertContains('<li class="page-item active disabled" aria-current="page"><a class="page-link" href="/?r=test&amp;page=6" data-page="5" tabindex="-1">6</a></li>', $output);
+        $this->assertStringContainsString('<li class="page-item active disabled" aria-current="page"><a class="page-link" href="/?r=test&amp;page=6" data-page="5" tabindex="-1">6</a></li>', $output);
     }
 
     public function testOptionsWithTagOption()
@@ -100,11 +100,11 @@ class LinkPagerTest extends TestCase
                 'class' => 'my-class',
             ],
         ]);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<div class="my-class page-item"><a class="page-link" href="/?r=test&amp;page=3" data-page="2">3</a></div>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<div class="my-class page-item active" aria-current="page"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></div>',
             $output
         );
@@ -125,7 +125,7 @@ class LinkPagerTest extends TestCase
         $this->assertTrue($initTriggered);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockWebApplication([

--- a/tests/ModalTest.php
+++ b/tests/ModalTest.php
@@ -108,7 +108,7 @@ HTML;
         Modal::end();
         $out = ob_get_clean();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#w0">Launch demo modal</button>',
             $out
         );

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -46,9 +46,9 @@ EXPECTED;
             'brandUrl' => '/',
         ]);
 
-        $this->assertContains('<a class="navbar-brand" href="/"><img src="/images/test.jpg" alt=""></a>', $out);
+        $this->assertStringContainsString('<a class="navbar-brand" href="/"><img src="/images/test.jpg" alt=""></a>', $out);
     }
-    
+
     public function testBrandImageOptions()
     {
         $out = NavBar::widget([
@@ -57,7 +57,7 @@ EXPECTED;
             'brandUrl' => '/',
         ]);
 
-        $this->assertContains('<a class="navbar-brand" href="/"><img src="/images/test.jpg" alt="test image"></a>', $out);
+        $this->assertStringContainsString('<a class="navbar-brand" href="/"><img src="/images/test.jpg" alt="test image"></a>', $out);
     }
 
     public function testBrandLink()
@@ -67,7 +67,7 @@ EXPECTED;
             'brandUrl' => false,
         ]);
 
-        $this->assertContains('<a class="navbar-brand" href="/index.php">Yii Framework</a>', $out);
+        $this->assertStringContainsString('<a class="navbar-brand" href="/index.php">Yii Framework</a>', $out);
     }
 
     public function testBrandSpan()
@@ -77,7 +77,7 @@ EXPECTED;
             'brandUrl' => null,
         ]);
 
-        $this->assertContains('<span class="navbar-brand">Yii Framework</span>', $out);
+        $this->assertStringContainsString('<span class="navbar-brand">Yii Framework</span>', $out);
     }
 
     /**

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -347,7 +347,7 @@ EXPECTED;
         $this->assertEqualsWithoutLE($expected, $out);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockWebApplication([
             'components' => [

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -86,7 +86,7 @@ HTML;
         Offcanvas::end();
         $out = ob_get_clean();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<button type="button" class="btn btn-primary" data-bs-toggle="offcanvas" data-bs-target="#w0" aria-controls="w0">Launch demo offcanvas</button>',
             $out
         );

--- a/tests/PopoverTest.php
+++ b/tests/PopoverTest.php
@@ -36,7 +36,7 @@ HTML;
 
         $js = Yii::$app->view->js[View::POS_READY];
 
-        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $this->assertIsArray($js);
         $options = array_shift($js);
 
         $this->assertContainsWithoutLE("(new bootstrap.Popover('#w0', {", $options);
@@ -55,7 +55,7 @@ HTML;
 
         $js = Yii::$app->view->js[View::POS_READY];
 
-        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $this->assertIsArray($js);
         $options = array_shift($js);
 
         $this->assertContainsWithoutLE('"content":"\u003Cspan class=\u0022test-content\u0022\u003ETest content\u003C\/span\u003E"', $options);

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -140,11 +140,11 @@ class TabsTest extends TestCase
             ]
         ]);
 
-        $this->assertNotContains('InvisiblePage', $html);
-        $this->assertNotContains('Invisible Page Content', $html);
-        $this->assertNotContains('InvisibleItem', $html);
-        $this->assertNotContains('Invisible Item Content', $html);
-        $this->assertNotContains('Invisible External Link', $html);
+        $this->assertStringNotContainsString('InvisiblePage', $html);
+        $this->assertStringNotContainsString('Invisible Page Content', $html);
+        $this->assertStringNotContainsString('InvisibleItem', $html);
+        $this->assertStringNotContainsString('Invisible Item Content', $html);
+        $this->assertStringNotContainsString('Invisible External Link', $html);
     }
 
     public function testDisabled()
@@ -179,23 +179,23 @@ class TabsTest extends TestCase
             ]
         ]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="nav-item"><a class="nav-link disabled" href="#w0-tab0" data-bs-toggle="tab" role="tab" aria-controls="w0-tab0" aria-disabled="true" tabindex="-1">Page1</a></li>',
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="nav-item"><a class="nav-link active" href="#w0-tab1" data-bs-toggle="tab" role="tab" aria-controls="w0-tab1" aria-selected="true">Page2</a></li>',
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="nav-item"><a class="nav-link disabled" href="#w0-tab2" data-bs-toggle="tab" role="tab" aria-controls="w0-tab2" aria-disabled="true" tabindex="-1">DisabledPage</a></li>',
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="dropdown-item disabled" href="#w0-dd3-tab1" data-bs-toggle="tab" role="tab" aria-controls="w0-dd3-tab1" aria-disabled="true" tabindex="-1">DisabledItem</a>',
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="dropdown-item disabled" href="/index.php?r=other%2Fdropdown%2Froute" tabindex="-1" aria-disabled="true">Disabled External Link</a>',
             $html
         );
@@ -220,13 +220,13 @@ class TabsTest extends TestCase
             'renderTabContent' => true,
         ]);
 
-        $this->assertContains('<' . $checkTag, $out);
+        $this->assertStringContainsString('<' . $checkTag, $out);
     }
 
     public function testTabContentOptions()
     {
-        $checkAttribute = "test_attribute";
-        $checkValue = "check_attribute";
+        $checkAttribute = 'test_attribute';
+        $checkValue = 'check_attribute';
 
         $out = Tabs::widget([
             'items' => [
@@ -240,8 +240,8 @@ class TabsTest extends TestCase
             ]
         ]);
 
-        $this->assertContains($checkAttribute . '=', $out);
-        $this->assertContains($checkValue, $out);
+        $this->assertStringContainsString($checkAttribute . '=', $out);
+        $this->assertStringContainsString($checkValue, $out);
     }
 
     public function testActivateFirstVisibleTab()
@@ -270,15 +270,15 @@ class TabsTest extends TestCase
             ]
         ]);
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '<li class="nav-item"><a class="nav-link active" href="#mytab-tab0" data-bs-toggle="tab" role="tab" aria-controls="mytab-tab0" aria-selected="true">Tab 1</a></li>',
             $html
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '<li class="nav-item"><a class="nav-link active" href="#mytab-tab1" data-bs-toggle="tab" role="tab" aria-controls="mytab-tab1" aria-selected="true">Tab 2</a></li>',
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="nav-item"><a class="nav-link active" href="#mytab-tab2" data-bs-toggle="tab" role="tab" aria-controls="mytab-tab2" aria-selected="true">Tab 3</a></li>',
             $html
         );
@@ -309,7 +309,7 @@ class TabsTest extends TestCase
                 ]
             ]
         ]);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="nav-item"><a class="nav-link active" href="#mytab-tab2" data-bs-toggle="tab" role="tab" aria-controls="mytab-tab2" aria-selected="true">Tab 3</a></li>',
             $html
         );
@@ -336,9 +336,9 @@ class TabsTest extends TestCase
                 ],
             ]
         ]);
-        $this->assertContains('&lt;span&gt;encoded&lt;/span&gt;', $html);
-        $this->assertContains('<span>not encoded</span>', $html);
-        $this->assertContains('<span>not encoded too</span>', $html);
+        $this->assertStringContainsString('&lt;span&gt;encoded&lt;/span&gt;', $html);
+        $this->assertStringContainsString('<span>not encoded</span>', $html);
+        $this->assertStringContainsString('<span>not encoded too</span>', $html);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -102,7 +102,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param string|null $moduleID
      * @param array $params
      */
-    protected function mockAction(string $controllerId, string $actionID, string $moduleID = null, array $params = [])
+    protected function mockAction(string $controllerId, string $actionID, string|null $moduleID = null, array $params = [])
     {
         Yii::$app->controller = $controller = new Controller($controllerId, Yii::$app);
         $controller->actionParams = $params;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,13 +39,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $needle = str_replace("\r\n", "\n", $needle);
         $haystack = str_replace("\r\n", "\n", $haystack);
 
-        $this->assertContains($needle, $haystack);
+        $this->assertStringContainsString($needle, $haystack);
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockWebApplication();
@@ -54,7 +54,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritDoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->destroyApplication();
@@ -102,7 +102,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param string|null $moduleID
      * @param array $params
      */
-    protected function mockAction(string $controllerId, string $actionID, string|null $moduleID = null, array $params = [])
+    protected function mockAction(string $controllerId, string $actionID, ?string $moduleID = null, array $params = [])
     {
         Yii::$app->controller = $controller = new Controller($controllerId, Yii::$app);
         $controller->actionParams = $params;

--- a/tests/ToastTest.php
+++ b/tests/ToastTest.php
@@ -130,14 +130,14 @@ HTML;
         ]);
         echo 'test';
         Toast::end();
-        $out = ob_get_clean();
+        ob_get_clean();
 
-        $this->assertInternalType(IsType::TYPE_ARRAY, $toast->clientOptions);
+        $this->assertIsArray($toast->clientOptions);
         $this->assertCount(0, $toast->clientOptions);
 
         $js = Yii::$app->view->js[View::POS_READY];
 
-        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $this->assertIsArray($js);
         $options = array_shift($js);
 
         $this->assertContainsWithoutLE("(new bootstrap.Toast('#w0', {}));", $options);
@@ -157,7 +157,7 @@ HTML;
         ]);
         echo 'test';
         Toast::end();
-        $out = ob_get_clean();
+        ob_get_clean();
 
         $this->assertFalse($toast->clientOptions);
         $this->assertArrayHasKey(View::POS_READY, Yii::$app->view->js);
@@ -174,13 +174,13 @@ HTML;
         ]);
         echo 'test';
         Toast::end();
-        $out = ob_get_clean();
+        ob_get_clean();
 
         $this->assertArrayHasKey('delay', $toast->clientOptions);
         $this->assertArrayHasKey(View::POS_READY, Yii::$app->view->js);
         $js = Yii::$app->view->js[View::POS_READY];
 
-        $this->assertInternalType(IsType::TYPE_ARRAY, $js);
+        $this->assertIsArray($js);
         $options = array_shift($js);
 
         $this->assertContainsWithoutLE("(new bootstrap.Toast('#w0', {\"delay\":1000}));", $options);

--- a/tests/ToggleButtonGroupTest.php
+++ b/tests/ToggleButtonGroupTest.php
@@ -48,7 +48,7 @@ HTML;
             ],
         ]);
 
-        $this->assertContains('<input type="checkbox" id="i1" class="btn-check" name="ToggleButtonGroupTestModel[value][]" value="2" checked autocomplete="off">', $html);
+        $this->assertStringContainsString('<input type="checkbox" id="i1" class="btn-check" name="ToggleButtonGroupTestModel[value][]" value="2" checked autocomplete="off">', $html);
     }
 
     public function testRadio()
@@ -88,7 +88,7 @@ HTML;
             ],
         ]);
 
-        $this->assertContains('<input type="radio" id="i1" class="btn-check" name="ToggleButtonGroupTestModel[value]" value="2" checked autocomplete="off">', $html);
+        $this->assertStringContainsString('<input type="radio" id="i1" class="btn-check" name="ToggleButtonGroupTestModel[value]" value="2" checked autocomplete="off">', $html);
     }
 }
 

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -11,7 +11,7 @@ use yii\bootstrap5\Breadcrumbs;
 
 class TranslationTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockWebApplication([
             'language' => 'de-CH',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #92
