### PR TITLE
Fix: ActiveField.php

### DIFF
--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -608,7 +608,7 @@ class ActiveField extends \yii\widgets\ActiveField
      * @param string|null $label the label or null to use model label
      * @param array $options the tag options
      */
-    protected function renderLabelParts(string $label = null, array $options = [])
+    protected function renderLabelParts(?string $label = null, array $options = [])
     {
         $options = array_merge($this->labelOptions, $options);
         if ($label === null) {


### PR DESCRIPTION
fix: yii\bootstrap5\ActiveField::renderLabelParts(): Implicitly marking parameter $label as nullable is deprecated, the explicit nullable type must be used instead

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
