### PR TITLE
Fix: BootstrapWidgetTrait.php

### DIFF
--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -106,7 +106,7 @@ trait BootstrapWidgetTrait
     /**
      * Registers JS event handlers that are listed in [[clientEvents]].
      */
-    protected function registerClientEvents(string $name = null)
+    protected function registerClientEvents(?string $name = null)
     {
         if (!empty($this->clientEvents)) {
             $id = $this->options['id'];


### PR DESCRIPTION
Fix: During class fetch: Uncaught yii\base\ErrorException: yii\bootstrap5\BootstrapWidgetTrait::registerClientEvents(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/yiisoft/yii2-bootstrap5/src/BootstrapWidgetTrait.php:112

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
