### PR TITLE
Refactor widget initialization methods to remove return type declarations in `init()` method and enhance documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Enh #106: Applying Yii2 coding standards (@s1lver)
 - Enh #106: Raise min version to PHP 7.4 (@s1lver)
 - Bug #107: Enhance `README.md` and `internals.md` documentation; update scripts in `composer.json` (@terabytesoftw)
+- Bug #109: Refactor widget initialization methods to remove return type declarations in `init()` method and enhance documentation (@terabytesoftw)
 
 2.0.51 December 03, 2025
 ------------------------

--- a/src/ActiveForm.php
+++ b/src/ActiveForm.php
@@ -108,11 +108,12 @@ class ActiveForm extends \yii\widgets\ActiveForm
     public $errorSummaryCssClass = 'alert alert-danger';
     public $validationStateOn = self::VALIDATION_STATE_ON_INPUT;
 
-
     /**
      * @throws InvalidConfigException
+     *
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         if (!in_array($this->layout, [self::LAYOUT_DEFAULT, self::LAYOUT_HORIZONTAL, self::LAYOUT_INLINE, self::LAYOUT_FLOATING], true)) {
             throw new InvalidConfigException('Invalid layout type: ' . $this->layout);

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -69,8 +70,13 @@ class Alert extends Widget
      */
     public $closeButton = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -56,8 +56,9 @@ trait BootstrapWidgetTrait
      * This method will register the bootstrap asset bundle. If you override this method,
      * make sure you call the parent implementation first.
      * @throws InvalidConfigException
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         parent::init();
         if (!isset($this->options['id'])) {

--- a/src/Button.php
+++ b/src/Button.php
@@ -46,8 +46,9 @@ class Button extends Widget
      * Initializes the widget.
      * If you override this method, make sure you call the parent implementation first.
      * @throws InvalidConfigException
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -12,6 +12,7 @@ namespace yii\bootstrap5;
 
 use Throwable;
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Url;
 
@@ -104,7 +105,13 @@ class ButtonDropdown extends Widget
      */
     public $renderContainer = true;
 
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/ButtonGroup.php
+++ b/src/ButtonGroup.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Throwable;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -61,8 +62,13 @@ class ButtonGroup extends Widget
      */
     public $encodeLabels = true;
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/ButtonToolbar.php
+++ b/src/ButtonToolbar.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Throwable;
+use yii\base\InvalidConfigException;
 
 /**
  * ButtonToolbar Combines sets of button groups into button toolbars for more complex components.
@@ -67,8 +68,13 @@ class ButtonToolbar extends Widget
      */
     public $buttonGroups = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/Carousel.php
+++ b/src/Carousel.php
@@ -81,11 +81,13 @@ class Carousel extends Widget
         ],
     ];
 
-
-    /**
+     /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
      * @throws InvalidConfigException
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/Carousel.php
+++ b/src/Carousel.php
@@ -81,7 +81,7 @@ class Carousel extends Widget
         ],
     ];
 
-     /**
+    /**
      * Initializes the widget.
      * If you override this method, make sure you call the parent implementation first.
      * @throws InvalidConfigException

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -68,8 +68,13 @@ class Dropdown extends Widget
      */
     public $submenuOptions = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/LinkPager.php
+++ b/src/LinkPager.php
@@ -148,12 +148,13 @@ class LinkPager extends Widget
      */
     public $disableCurrentPageButton = false;
 
-
     /**
-     * Initializes the pager.
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
      * @throws InvalidConfigException
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         parent::init();
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -138,11 +138,13 @@ class Modal extends Widget
      */
     public $dialogOptions = [];
 
-
     /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
      * @throws InvalidConfigException
+     * @return void
      */
-    public function init(): void
+    public function init()
     {
         parent::init();
 

--- a/src/Nav.php
+++ b/src/Nav.php
@@ -109,8 +109,13 @@ class Nav extends Widget
      */
     public $dropdownClass = Dropdown::class;
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         if ($this->route === null && Yii::$app->controller !== null) {

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -119,8 +120,13 @@ class NavBar extends Widget
     public $innerContainerOptions = [];
     public $clientOptions = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         if (!isset($this->options['class']) || empty($this->options['class'])) {

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -109,8 +110,13 @@ class Offcanvas extends Widget
      */
     public $bodyOptions = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/Popover.php
+++ b/src/Popover.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace yii\bootstrap5;
 
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -85,8 +86,13 @@ class Popover extends Widget
      */
     public $toggleButton = false;
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/Progress.php
+++ b/src/Progress.php
@@ -115,8 +115,13 @@ class Progress extends Widget
      */
     public $bars;
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -141,8 +141,13 @@ class Tabs extends Widget
      */
     protected $panes = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         Html::addCssClass($this->options, [

--- a/src/Toast.php
+++ b/src/Toast.php
@@ -14,6 +14,7 @@ use DateInterval;
 use DateTime;
 use DateTimeInterface;
 use Yii;
+use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -109,8 +110,13 @@ class Toast extends Widget
      */
     public $bodyOptions = [];
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
 

--- a/src/ToggleButtonGroup.php
+++ b/src/ToggleButtonGroup.php
@@ -66,8 +66,13 @@ class ToggleButtonGroup extends InputWidget
      */
     public $encodeLabels = true;
 
-
-    public function init(): void
+    /**
+     * Initializes the widget.
+     * If you override this method, make sure you call the parent implementation first.
+     * @throws InvalidConfigException
+     * @return void
+     */
+    public function init()
     {
         parent::init();
         $this->registerPlugin('button');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
