### PR TITLE
Fix #115: Remove unnecessary `@property` annotations in `LinkPager` and `NavBar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Bug #107: Enhance `README.md` and `internals.md` documentation; update scripts in `composer.json` (@terabytesoftw)
 - Bug #108: Fix logo image sources in `README.md` for correct color scheme display (@terabytesoftw)
 - Bug #109: Refactor widget initialization methods to remove return type declarations in `init()` method and enhance documentation (@terabytesoftw)
-- Bug #TBD: Fix `@property` annotations in `LinkPager` and `NavBar` (mspirkov)
+- Bug #115: Remove unnecessary `@property` annotations in `LinkPager` and `NavBar` (mspirkov)
 
 2.0.51 December 03, 2025
 ------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 bootstrap5 extension Change Log
 - Bug #107: Enhance `README.md` and `internals.md` documentation; update scripts in `composer.json` (@terabytesoftw)
 - Bug #108: Fix logo image sources in `README.md` for correct color scheme display (@terabytesoftw)
 - Bug #109: Refactor widget initialization methods to remove return type declarations in `init()` method and enhance documentation (@terabytesoftw)
+- Bug #TBD: Fix `@property` annotations in `LinkPager` and `NavBar` (mspirkov)
 
 2.0.51 December 03, 2025
 ------------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -487,12 +487,6 @@ parameters:
 			path: src/InputWidget.php
 
 		-
-			message: '#^Class yii\\bootstrap5\\LinkPager has PHPDoc tag @property\-read for property \$pageRange with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/LinkPager.php
-
-		-
 			message: '#^Method yii\\bootstrap5\\LinkPager\:\:getPageRange\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -589,6 +583,18 @@ parameters:
 			path: src/Nav.php
 
 		-
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 4
+			path: src/Nav.php
+
+		-
+			message: '#^Cannot access property \$request on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Nav.php
+
+		-
 			message: '#^Method yii\\bootstrap5\\Nav\:\:isChildActive\(\) has parameter \$items with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -637,20 +643,14 @@ parameters:
 			path: src/Nav.php
 
 		-
-			message: '#^Access to an undefined property yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\:\:\$homeUrl\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/NavBar.php
-
-		-
 			message: '#^Cannot access offset ''id'' on array\|true\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 6
 			path: src/NavBar.php
 
 		-
-			message: '#^Class yii\\bootstrap5\\NavBar has PHPDoc tag @property\-write for property \$containerOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Cannot access property \$homeUrl on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/NavBar.php
 
@@ -751,18 +751,6 @@ parameters:
 			path: src/NavBar.php
 
 		-
-			message: '#^Variable \$aria might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/NavBar.php
-
-		-
-			message: '#^Variable \$bsData might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/NavBar.php
-
-		-
 			message: '#^Property yii\\bootstrap5\\Offcanvas\:\:\$bodyOptions type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -853,6 +841,18 @@ parameters:
 			path: src/Progress.php
 
 		-
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Tabs.php
+
+		-
+			message: '#^Cannot access property \$view on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Tabs.php
+
+		-
 			message: '#^Method yii\\bootstrap5\\Tabs\:\:prepareItems\(\) has parameter \$items with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -905,6 +905,12 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Tabs.php
+
+		-
+			message: '#^Cannot access property \$formatter on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Toast.php
 
 		-
 			message: '#^Property yii\\bootstrap5\\Toast\:\:\$bodyOptions type has no value type specified in iterable type array\.$#'
@@ -1285,6 +1291,12 @@ parameters:
 			path: tests/ButtonDropdownTest.php
 
 		-
+			message: '#^Cannot access property \$view on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/ButtonDropdownTest.php
+
+		-
 			message: '#^Method yiiunit\\extensions\\bootstrap5\\ButtonGroupTest\:\:testContainerOptions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1639,6 +1651,12 @@ parameters:
 			path: tests/PopoverTest.php
 
 		-
+			message: '#^Cannot access property \$view on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/PopoverTest.php
+
+		-
 			message: '#^Method yiiunit\\extensions\\bootstrap5\\PopoverTest\:\:testButtonRender\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1679,6 +1697,12 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: tests/ProgressTest.php
+
+		-
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/TestCase.php
 
 		-
 			message: '#^Method yiiunit\\extensions\\bootstrap5\\TestCase\:\:assertContainsWithoutLE\(\) has no return type specified\.$#'
@@ -1729,19 +1753,13 @@ parameters:
 			path: tests/TestCase.php
 
 		-
+			message: '#^Parameter \#2 \$module of class yii\\web\\Controller constructor expects yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>, yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/TestCase.php
+
+		-
 			message: '#^Property yii\\base\\Controller\<yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\>\:\:\$module \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept yii\\base\\Module\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/TestCase.php
-
-		-
-			message: '#^Property yii\\console\\Application\:\:\$controller \(yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\) does not accept yii\\web\\Controller\<yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/TestCase.php
-
-		-
-			message: '#^Static property yii\\BaseYii\<yii\\web\\IdentityInterface\>\:\:\$app \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/TestCase.php
@@ -1750,6 +1768,12 @@ parameters:
 			message: '#^Access to an undefined property yii\\base\\View\:\:\$js\.$#'
 			identifier: property.notFound
 			count: 3
+			path: tests/ToastTest.php
+
+		-
+			message: '#^Cannot access property \$view on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 4
 			path: tests/ToastTest.php
 
 		-

--- a/src/LinkPager.php
+++ b/src/LinkPager.php
@@ -34,8 +34,6 @@ use yii\helpers\ArrayHelper;
  * @see https://getbootstrap.com/docs/5.1/components/pagination/
  * @author Simon Karlen <simi.albi@outlook.com>
  * @since 2.0.2
- *
- * @property-read array $pageRange
  */
 class LinkPager extends Widget
 {

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -35,9 +35,6 @@ use yii\helpers\ArrayHelper;
  * ]);
  * NavBar::end();
  * ```
- *
- * @property-write array $containerOptions
- *
  * @see https://getbootstrap.com/docs/5.1/components/navbar/
  * @author Antonio Ramirez <amigo.cobos@gmail.com>
  * @author Alexander Kochetov <creocoder@gmail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042