### PR TITLE
Fix `ActiveField::checkbox()`/`radio()` dropping the model-generated label in the default non-enclosed layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Yii Framework 2 bootstrap5 extension Change Log
 ==============================================
 
+22.0.0 under development
+------------------------
+- Bug #117: Fix `ActiveField::checkbox()`/`radio()` dropping the model-generated label in the default non-enclosed layout (@terabytesoftw)
+
 3.0.0 under development
 ------------------------
 

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -314,8 +314,6 @@ class ActiveField extends \yii\widgets\ActiveField
             if (isset($options['label'])) {
                 $this->parts['{labelTitle}'] = $options['label'];
             }
-        } else {
-            $this->renderCheckLabel($options);
         }
 
         parent::checkbox($options, false);
@@ -348,12 +346,8 @@ class ActiveField extends \yii\widgets\ActiveField
         Html::removeCssClass($this->labelOptions, 'form-label');
         unset($options['template']);
 
-        if ($enclosedByLabel) {
-            if (isset($options['label'])) {
-                $this->parts['{labelTitle}'] = $options['label'];
-            }
-        } else {
-            $this->renderCheckLabel($options);
+        if ($enclosedByLabel && isset($options['label'])) {
+            $this->parts['{labelTitle}'] = $options['label'];
         }
 
         parent::radio($options, false);
@@ -636,25 +630,6 @@ class ActiveField extends \yii\widgets\ActiveField
         }
 
         return $config;
-    }
-
-    /**
-     * Renders the `{label}` part of a checkbox or radio that is not enclosed by its label.
-     *
-     * [[\yii\widgets\ActiveField::checkbox()]] and [[\yii\widgets\ActiveField::radio()]] pin `{label}` to an empty
-     * string when the `label` option is absent, so the part must be built before delegating to keep the
-     * `form-check-label` markup. A `label` option set to `false` disables the label.
-     *
-     * @param array<array-key, mixed> $options the input tag options passed to the parent renderer.
-     */
-    protected function renderCheckLabel(array $options): void
-    {
-        if ($this->enableLabel === false || isset($this->parts['{label}'])) {
-            return;
-        }
-
-        $this->adjustLabelFor($options);
-        $this->label($options['label'] ?? null);
     }
 
     /**

--- a/tests/ActiveFieldTest.php
+++ b/tests/ActiveFieldTest.php
@@ -416,6 +416,38 @@ HTML;
         $this->assertStringContainsString('</label>', $html, 'Enclosing label must close.');
     }
 
+    public function testCheckboxEnclosedByLabelWithCustomLabelOption(): void
+    {
+        $html = $this->activeField->checkbox(['label' => 'Custom Label'], true)->render();
+
+        $this->assertStringContainsString(
+            'Custom Label',
+            $html,
+            'Custom label text must override the model attribute label.',
+        );
+        $this->assertStringNotContainsString(
+            'Attribute Name',
+            $html,
+            'Model attribute label must not appear when a custom label is set.',
+        );
+    }
+
+    public function testRadioEnclosedByLabelWithCustomLabelOption(): void
+    {
+        $html = $this->activeField->radio(['label' => 'Custom Label'], true)->render();
+
+        $this->assertStringContainsString(
+            'Custom Label',
+            $html,
+            'Custom label text must override the model attribute label.',
+        );
+        $this->assertStringNotContainsString(
+            'Attribute Name',
+            $html,
+            'Model attribute label must not appear when a custom label is set.',
+        );
+    }
+
     protected function setUp(): void
     {
         // dirty way to have Request object not throwing exception when running testHomeLinkNull()

--- a/tests/ActiveFieldTest.php
+++ b/tests/ActiveFieldTest.php
@@ -336,6 +336,86 @@ HTML;
         $this->assertStringContainsString('data-attribute="test"', $content);
     }
 
+    public function testCheckboxRendersModelLabel(): void
+    {
+        $html = $this->activeField->checkbox()->render();
+
+        $this->assertStringContainsString(
+            'class="form-check-label"',
+            $html,
+            'Label with form-check-label class must appear.',
+        );
+        $this->assertStringContainsString(
+            'Attribute Name',
+            $html,
+            'Model attribute label text must be rendered.',
+        );
+    }
+
+    public function testRadioRendersModelLabel(): void
+    {
+        $html = $this->activeField->radio()->render();
+
+        $this->assertStringContainsString(
+            'class="form-check-label"',
+            $html,
+            'Label with form-check-label class must appear.',
+        );
+        $this->assertStringContainsString(
+            'Attribute Name',
+            $html,
+            'Model attribute label text must be rendered.',
+        );
+    }
+
+    public function testCheckboxSuppressesLabelWhenOptionIsFalse(): void
+    {
+        $html = $this->activeField->checkbox(['label' => false])->render();
+
+        $this->assertStringNotContainsString('<label', $html, 'Label tag must be absent.');
+    }
+
+    public function testRadioSuppressesLabelWhenOptionIsFalse(): void
+    {
+        $html = $this->activeField->radio(['label' => false])->render();
+
+        $this->assertStringNotContainsString('<label', $html, 'Label tag must be absent.');
+    }
+
+    public function testCheckboxEnclosedByLabelTrue(): void
+    {
+        $html = $this->activeField->checkbox([], true)->render();
+
+        $this->assertStringContainsString(
+            '<label class="form-check-label"',
+            $html,
+            'Enclosing label must open with form-check-label class.',
+        );
+        $this->assertStringContainsString(
+            'Attribute Name',
+            $html,
+            'Model label text must appear inside the enclosing element.',
+        );
+        $this->assertStringContainsString('</label>', $html, 'Enclosing label must close.');
+    }
+
+    public function testRadioEnclosedByLabelTrue(): void
+    {
+        $html = $this->activeField->radio([], true)->render();
+
+        $this->assertStringContainsString(
+            '<label class="form-check-label"',
+            $html,
+            'Enclosing label must open with form-check-label class.',
+        );
+        $this->assertStringContainsString(
+            'Attribute Name',
+            $html,
+            'Model label text must appear inside the enclosing element.',
+        );
+        $this->assertStringContainsString('</label>', $html, 'Enclosing label must close.');
+    }
+
     protected function setUp(): void
     {
         // dirty way to have Request object not throwing exception when running testHomeLinkNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
